### PR TITLE
Added cancel (test fails)

### DIFF
--- a/include/std/experimental/__detail/intrusive_list.hpp
+++ b/include/std/experimental/__detail/intrusive_list.hpp
@@ -15,7 +15,7 @@ template <auto _Next, auto _Prev> class intrusive_list;
 template <class _Item, _Item* _Item::*_Next, _Item* _Item::*_Prev>
 class intrusive_list<_Next, _Prev> {
 public:
-  bool empty() const { return head_ == nullptr; }
+  [[nodiscard]] bool empty() const { return head_ == nullptr; }
 
   // Insert an object at the front of the list
   void push_front(_Item* obj) {
@@ -26,11 +26,11 @@ public:
     // Update the head pointer
     if (head_)
       head_->*_Prev = obj;
-    head_ = obj;
-
-    // Update the tail pointer if the list was empty
-    if (!tail_)
+    else
+      // Update the tail pointer if the list was empty
       tail_ = obj;
+
+    head_ = obj;
   }
 
   // Insert an object at the back of the list
@@ -42,15 +42,15 @@ public:
     // Update the tail pointer
     if (tail_)
       tail_->*_Next = obj;
-    tail_ = obj;
-
-    // Update the head pointer if the list was empty
-    if (!head_)
+    else
+      // Update the head pointer if the list was empty
       head_ = obj;
+
+    tail_ = obj;
   }
 
   // Remove an object from the front of the list and return it
-  _Item* pop_front() {
+  [[nodiscard]] _Item* pop_front() {
     // Check if the list is empty
     if (!head_)
       return nullptr;
@@ -77,7 +77,7 @@ public:
   }
 
   // Remove an object from the back of the list and return it
-  _Item* pop_back() {
+  [[nodiscard]] _Item* pop_back() {
     // Check if the list is empty
     if (!tail_)
       return nullptr;

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -5,6 +5,7 @@
 #define _STD_EXPERIMENTAL_CONQUEUE
 #include "__detail/tracing.hpp"
 #include "stdexec/__detail/__execution_fwd.hpp"
+#include "stdexec/stop_token.hpp"
 
 #include <atomic>
 #include <deque>
@@ -395,16 +396,19 @@ template <typename T> struct buffer_queue<T>::pop_sender {
     struct cancel_callback {
       operation& self;
       void operator()() noexcept {
-        auto& cq = *self.sender.queue;
+        auto& cq = self.queue;
         unique_lock lock(cq.mutex);
-        // After we acquired lock, the operation might have already completed
-        // and was removed from the queue. Hence, try_remove.
+        // After we acquired the lock, the operation might have already
+        // completed and was removed from the queue. Hence, try_remove.
         if (cq.waiters.try_remove(&self)) {
           lock.unlock();
-          stdexec::set_stopped((Receiver&&)self->receiver);
+          stdexec::set_stopped((Receiver&&)self.receiver);
         }
       }
     };
+
+    optional<stdexec::in_place_stop_callback<cancel_callback>> stop_callback;
+    atomic<bool> ready{false};
 
     operation(buffer_queue& queue, Receiver&& receiver)
         : queue(queue), receiver(std::move(receiver)) {
@@ -421,7 +425,19 @@ template <typename T> struct buffer_queue<T>::pop_sender {
 
     friend void tag_invoke(stdexec::start_t, operation& op) noexcept {
       auto& self = op.queue;
+      auto& env = stdexec::get_env(op.receiver);
+      auto stop_token = stdexec::get_stop_token(env);
       std::unique_lock lock(self.mutex);
+      if (stop_token.stop_requested()) {
+        lock.unlock();
+        stdexec::set_stopped(std::move(op.receiver));
+        return;
+      }
+      // Store and cache result here in case it changes during execution
+      const bool stop_possible = stop_token.stop_possible();
+      if (!stop_possible) {
+        op.ready.store(true, std::memory_order_relaxed);
+      }
       // If the queue is empty, add ourselves to the waiters.
       if (self.queue.empty()) {
         // Unless, of course, the queue is closed, then return an error.
@@ -437,6 +453,10 @@ template <typename T> struct buffer_queue<T>::pop_sender {
             "async_pop: queue is empty, putting %p in the waiters queue\n",
             &op);
         self.waiters.push_back(&op);
+        // Now we are in the queue, set up cancellation callback.
+        if (stop_possible) {
+          op.stop_callback.emplace(stop_token, cancel_callback{op});
+        }
         return;
       }
 

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -4,8 +4,7 @@
 #ifndef _STD_EXPERIMENTAL_CONQUEUE
 #define _STD_EXPERIMENTAL_CONQUEUE
 #include "__detail/tracing.hpp"
-#include "stdexec/__detail/__execution_fwd.hpp"
-#include "stdexec/stop_token.hpp"
+#include <std/experimental/__detail/intrusive_list.hpp>
 
 #include <atomic>
 #include <deque>
@@ -16,8 +15,8 @@
 #include <system_error>
 #include <variant>
 
-#include <std/experimental/__detail/intrusive_list.hpp>
 #include <stdexec/execution.hpp>
+#include <stdexec/stop_token.hpp>
 
 namespace std::experimental {
 enum class conqueue_errc { success, empty, full, closed };
@@ -407,7 +406,10 @@ template <typename T> struct buffer_queue<T>::pop_sender {
       }
     };
 
-    optional<stdexec::in_place_stop_callback<cancel_callback>> stop_callback;
+    using __on_stop = std::optional<typename stdexec::stop_token_of_t<
+        stdexec::env_of_t<Receiver>&>::template callback_type<cancel_callback>>;
+
+    __on_stop stop_callback;
     atomic<bool> ready{false};
 
     operation(buffer_queue& queue, Receiver&& receiver)
@@ -425,18 +427,25 @@ template <typename T> struct buffer_queue<T>::pop_sender {
 
     friend void tag_invoke(stdexec::start_t, operation& op) noexcept {
       auto& self = op.queue;
-      auto& env = stdexec::get_env(op.receiver);
+      auto&& env = stdexec::get_env(op.receiver);
       auto stop_token = stdexec::get_stop_token(env);
+      constexpr bool sp = std::unstoppable_token<decltype(stop_token)>;
+
       std::unique_lock lock(self.mutex);
-      if (stop_token.stop_requested()) {
-        lock.unlock();
-        stdexec::set_stopped(std::move(op.receiver));
-        return;
+      if constexpr (sp) {
+        if (stop_token.stop_requested()) {
+          lock.unlock();
+          stdexec::set_stopped(std::move(op.receiver));
+          return;
+        }
       }
+
       // Store and cache result here in case it changes during execution
       const bool stop_possible = stop_token.stop_possible();
-      if (!stop_possible) {
-        op.ready.store(true, std::memory_order_relaxed);
+      if constexpr (sp) {
+        if (!stop_possible) {
+          op.ready.store(true, std::memory_order_relaxed);
+        }
       }
       // If the queue is empty, add ourselves to the waiters.
       if (self.queue.empty()) {
@@ -453,9 +462,11 @@ template <typename T> struct buffer_queue<T>::pop_sender {
             "async_pop: queue is empty, putting %p in the waiters queue\n",
             &op);
         self.waiters.push_back(&op);
-        // Now we are in the queue, set up cancellation callback.
-        if (stop_possible) {
-          op.stop_callback.emplace(stop_token, cancel_callback{op});
+        if constexpr (sp) {
+          // Now we are in the queue, set up cancellation callback.
+          if (stop_possible) {
+            op.stop_callback.emplace(stop_token, cancel_callback{op});
+          }
         }
         return;
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_executable(tests conqueue.test.cpp intrusive_list.test.cpp)
+add_executable(repro repro.cpp)
+target_link_libraries(repro PRIVATE stdexec)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain conqueue)
 catch_discover_tests(tests)

--- a/test/conqueue.test.cpp
+++ b/test/conqueue.test.cpp
@@ -25,6 +25,9 @@ exec::task<void> coro_push(buffer_queue<int>& q) {
 }
 
 exec::task<void> coro_pop(buffer_queue<int>& q) {
+  auto stop_token = co_await stdexec::get_stop_token();
+  printf("stop possible: %d\n", stop_token.stop_possible());
+
   REQUIRE(co_await q.async_pop() == 1);
   REQUIRE(co_await q.async_pop() == 2);
   REQUIRE(co_await q.async_pop() == 3);

--- a/test/conqueue.test.cpp
+++ b/test/conqueue.test.cpp
@@ -130,10 +130,11 @@ TEST_CASE("conqueue: coro_pop") {
 
 TEST_CASE("conqueue: cancellation") {
   exec::static_thread_pool pool(1);
+  auto sched = pool.get_scheduler();
   exec::async_scope scope;
   buffer_queue<int> q(2);
 
-  scope.spawn(on(pool.get_scheduler(), coro_pop(q)));
+  scope.spawn(on(sched, coro_pop(q)));
   std::this_thread::sleep_for(10ms);
   scope.request_stop();
   stdexec::sync_wait(scope.on_empty());

--- a/test/repro.cpp
+++ b/test/repro.cpp
@@ -1,0 +1,17 @@
+#include <exec/async_scope.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <exec/task.hpp>
+#include <iostream>
+#include <stdexec/execution.hpp>
+
+exec::task<void> coro() {
+  auto stop_token = co_await stdexec::get_stop_token();
+  std::cout << "stop possible: " << stop_token.stop_possible() << "\n";
+}
+
+int main() {
+  exec::static_thread_pool pool(1);
+  exec::async_scope scope;
+  scope.spawn(stdexec::on(pool.get_scheduler(), coro()));
+  stdexec::sync_wait(scope.on_empty());
+}


### PR DESCRIPTION
Added cancel.
It seems that in the test stop_token is not propagated from scope.spawn into a coroutine. Did not debug it yet