### PR TITLE
Even better cancellation (both pop and push)

### DIFF
--- a/include/std/experimental/__detail/easy_cancel.hpp
+++ b/include/std/experimental/__detail/easy_cancel.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 Gor Nishanov
+// Licensed under MIT license. See LICENSE.txt for details.
+
+#ifndef _STD_EXPERIMENTAL_CONQUEUE_EASY_CANCEL
+#define _STD_EXPERIMENTAL_CONQUEUE_EASY_CANCEL
+
+#include <cassert>
+#include <stdexec/execution.hpp>
+#include <variant>
+
+namespace std::experimental::__detail {
+
+template <typename Receiver, typename CancelCallback, typename StopToken,
+          bool Unstoppable>
+struct easy_cancel_base;
+
+template <typename Receiver, typename CancelCallback, typename StopToken>
+struct easy_cancel_base<Receiver, CancelCallback, StopToken, false> {
+  using StopCallback =
+      typename StopToken::template callback_type<CancelCallback>;
+
+  variant<monostate, StopToken, StopCallback> state;
+
+  easy_cancel_base(Receiver& receiver)
+      : state(stdexec::get_stop_token(stdexec::get_env(receiver))) {}
+
+  bool stop_requested() {
+    if (auto* tok = std::get_if<StopToken>(&state))
+      return tok->stop_requested();
+
+    return false;
+  }
+
+  void register_callback(CancelCallback&& f) {
+    if (auto* tok = std::get_if<StopToken>(&state))
+      state.template emplace<2>(std::move(*tok), std::move(f));
+    else
+      assert(false);
+  }
+
+  void reset() { state.template emplace<0>(); }
+};
+
+template <typename Receiver, typename CancelCallback, typename StopToken>
+struct easy_cancel_base<Receiver, CancelCallback, StopToken, true> {
+  constexpr easy_cancel_base(Receiver&) {}
+
+  constexpr bool stop_requested() { return false; }
+
+  template <typename F> void register_callback(F&&) {}
+
+  void reset() {}
+};
+
+template <typename Receiver, typename CancelCallback,
+          typename StopToken =
+              stdexec::stop_token_of_t<stdexec::env_of_t<Receiver>>>
+struct easy_cancel : easy_cancel_base<Receiver, CancelCallback, StopToken,
+                                      stdexec::unstoppable_token<StopToken>> {
+  using base = easy_cancel_base<Receiver, CancelCallback, StopToken,
+                                stdexec::unstoppable_token<StopToken>>;
+
+  using base::base;
+};
+
+} // namespace std::experimental::__detail
+
+#endif // _STD_EXPERIMENTAL_CONQUEUE_EASY_CANCEL

--- a/include/std/experimental/__detail/easy_cancel.hpp
+++ b/include/std/experimental/__detail/easy_cancel.hpp
@@ -31,11 +31,9 @@ struct easy_cancel_base<Receiver, CancelCallback, StopToken, false> {
     return false;
   }
 
-  void register_callback(CancelCallback&& f) {
-    if (auto* tok = std::get_if<StopToken>(&state))
-      state.template emplace<2>(std::move(*tok), std::move(f));
-    else
-      assert(false);
+  void emplace(CancelCallback&& cancel_callback) {
+    auto token = std::move(std::get<StopToken>(state));
+    state.template emplace<2>(std::move(token), std::move(cancel_callback));
   }
 
   void reset() { state.template emplace<0>(); }

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -471,21 +471,28 @@ struct buffer_queue<T, Alloc>::pop_sender {
     struct cancel_callback {
       operation& self;
       void operator()() noexcept {
-        auto& cq = *self.sender.queue;
+        auto& cq = self.queue;
         unique_lock lock(cq.mutex);
-        // After we acquired lock, the operation might have already completed
-        // and was removed from the queue. Hence, try_remove.
-        if (cq.waiters.try_remove(&self)) {
+        // After we acquired the lock, the operation might have already
+        // completed and was removed from the queue. Hence, try_remove.
+        if (cq.pop_waiters.try_remove(&self)) {
           lock.unlock();
-          stdexec::set_stopped((Receiver&&)self->receiver);
+          self.stop_callback.reset();
+          stdexec::set_stopped((Receiver&&)self.receiver);
         }
       }
     };
+
+    using stop_callback_t = std::optional<typename stdexec::stop_token_of_t<
+        stdexec::env_of_t<Receiver>&>::template callback_type<cancel_callback>>;
+
+    stop_callback_t stop_callback;
 
     operation(buffer_queue& queue, Receiver&& receiver)
         : pop_waiter(result, ec), queue(queue), receiver(std::move(receiver)) {
       this->complete = [](pop_waiter* w) noexcept {
         auto& op = *static_cast<operation*>(w);
+        op.stop_callback.reset();
         if (op.result) {
           STDEX_CONQUEUE_LOG("async_pop: resumed with lvalue: %d\n",
                              *op.result);
@@ -501,6 +508,16 @@ struct buffer_queue<T, Alloc>::pop_sender {
 
     friend void tag_invoke(stdexec::start_t, operation& op) noexcept {
       auto& self = op.queue;
+      auto stop_token = stdexec::get_stop_token(stdexec::get_env(op.receiver));
+      constexpr bool stoppable = !std::unstoppable_token<decltype(stop_token)>;
+
+      if constexpr (stoppable) {
+        if (stop_token.stop_requested()) {
+          stdexec::set_stopped((Receiver&&)op.receiver);
+          return;
+        }
+      }
+
       std::unique_lock lock(self.mutex);
       // If the queue is empty, add ourselves to the waiters.
       if (self.queue.empty()) {
@@ -537,6 +554,14 @@ struct buffer_queue<T, Alloc>::pop_sender {
             "async_pop: queue is empty, putting %p in the waiters queue\n",
             &op);
         self.pop_waiters.push_back(&op);
+        lock.unlock();
+
+        if constexpr (stoppable) {
+          if (stop_token.stop_possible()) {
+            op.stop_callback.emplace(std::move(stop_token),
+                                     cancel_callback{op});
+          }
+        }
         return;
       }
 

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -288,23 +288,42 @@ struct buffer_queue<T, Alloc>::push_sender {
   T value;
 
   using is_sender = void;
-  using completion_signatures = // TODO: Cancellation support.
+  using completion_signatures =
       stdexec::completion_signatures<stdexec::set_value_t(),
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
 
   template <typename Receiver> struct operation : push_waiter {
     buffer_queue& queue;
-    Receiver receiver;
     T value;
     std::error_code ec;
 
+    struct cancel_callback {
+      operation& self;
+      void operator()() noexcept {
+        auto& cq = self.queue;
+        unique_lock lock(cq.mutex);
+        // After we acquired the lock, the operation might have already
+        // completed and was removed from the queue. Hence, try_remove.
+        if (cq.push_waiters.try_remove(&self)) {
+          lock.unlock();
+          self.easy_cancel.reset();
+          STDEX_CONQUEUE_LOG("push_waiter %p cancelled\n", &self);
+          stdexec::set_stopped((Receiver&&)self.receiver);
+        }
+      }
+    };
+
+    __detail::easy_cancel<Receiver, cancel_callback> easy_cancel;
+    Receiver receiver;
+
     operation(push_sender&& sender, Receiver&& receiver)
-        : push_waiter(ec), queue(sender.queue), receiver(std::move(receiver)),
-          value(std::move(sender.value)) {
+        : push_waiter(ec), queue(sender.queue), easy_cancel(receiver),
+          receiver(std::move(receiver)), value(std::move(sender.value)) {
       this->lval = std::addressof(value);
       this->complete = [](push_waiter* w) noexcept {
         auto& op = *static_cast<operation*>(w);
+        op.easy_cancel.reset();
         if (op.ec)
           stdexec::set_error((Receiver&&)op.receiver,
                              make_exception_ptr(conqueue_error(op.ec)));
@@ -315,6 +334,10 @@ struct buffer_queue<T, Alloc>::push_sender {
 
     friend void tag_invoke(stdexec::start_t, operation& op) noexcept {
       auto& self = op.queue;
+      if (op.easy_cancel.stop_requested()) {
+        stdexec::set_stopped((Receiver&&)op.receiver);
+        return;
+      }
       std::unique_lock lock(self.mutex);
       if (self.closed) {
         lock.unlock();
@@ -338,12 +361,15 @@ struct buffer_queue<T, Alloc>::push_sender {
               "async_push: queue is full, putting %p in the waiters queue\n",
               &op);
           self.push_waiters.push_back(&op);
+          lock.unlock();
+          op.easy_cancel.register_callback(cancel_callback{op});
           return;
         }
 
         STDEX_CONQUEUE_LOG("async push: queue is not full, pushing value %d\n",
                            op.value);
         self.queue.push_back(std::move(op.value));
+        lock.unlock();
       }
       stdexec::set_value((Receiver&&)op.receiver);
     }
@@ -458,7 +484,7 @@ struct buffer_queue<T, Alloc>::pop_sender {
   buffer_queue* queue;
 
   using is_sender = void;
-  using completion_signatures = // TODO: Cancellation support.
+  using completion_signatures =
       stdexec::completion_signatures<stdexec::set_value_t(T),
                                      stdexec::set_error_t(std::exception_ptr),
                                      stdexec::set_stopped_t()>;
@@ -478,6 +504,7 @@ struct buffer_queue<T, Alloc>::pop_sender {
         if (cq.pop_waiters.try_remove(&self)) {
           lock.unlock();
           self.easy_cancel.reset();
+          STDEX_CONQUEUE_LOG("pop_waiter %p cancelled\n", &self);
           stdexec::set_stopped((Receiver&&)self.receiver);
         }
       }

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -362,7 +362,7 @@ struct buffer_queue<T, Alloc>::push_sender {
               &op);
           self.push_waiters.push_back(&op);
           lock.unlock();
-          op.easy_cancel.register_callback(cancel_callback{op});
+          op.easy_cancel.emplace(cancel_callback{op});
           return;
         }
 
@@ -578,7 +578,7 @@ struct buffer_queue<T, Alloc>::pop_sender {
         self.pop_waiters.push_back(&op);
         lock.unlock();
 
-        op.easy_cancel.register_callback(cancel_callback{op});
+        op.easy_cancel.emplace(cancel_callback{op});
         return;
       }
 

--- a/include/std/experimental/conqueue
+++ b/include/std/experimental/conqueue
@@ -12,6 +12,7 @@
 #include <optional>
 #include <system_error>
 
+#include <std/experimental/__detail/easy_cancel.hpp>
 #include <std/experimental/__detail/intrusive_list.hpp>
 #include <std/experimental/__detail/ring_buffer.hpp>
 #include <std/experimental/__detail/spinlock.hpp>
@@ -464,7 +465,6 @@ struct buffer_queue<T, Alloc>::pop_sender {
 
   template <typename Receiver> struct operation : pop_waiter {
     buffer_queue& queue;
-    Receiver receiver;
     std::optional<T> result;
     std::error_code ec;
 
@@ -477,22 +477,21 @@ struct buffer_queue<T, Alloc>::pop_sender {
         // completed and was removed from the queue. Hence, try_remove.
         if (cq.pop_waiters.try_remove(&self)) {
           lock.unlock();
-          self.stop_callback.reset();
+          self.easy_cancel.reset();
           stdexec::set_stopped((Receiver&&)self.receiver);
         }
       }
     };
 
-    using stop_callback_t = std::optional<typename stdexec::stop_token_of_t<
-        stdexec::env_of_t<Receiver>&>::template callback_type<cancel_callback>>;
-
-    stop_callback_t stop_callback;
+    __detail::easy_cancel<Receiver, cancel_callback> easy_cancel;
+    Receiver receiver;
 
     operation(buffer_queue& queue, Receiver&& receiver)
-        : pop_waiter(result, ec), queue(queue), receiver(std::move(receiver)) {
+        : pop_waiter(result, ec), queue(queue), easy_cancel(receiver),
+          receiver(std::move(receiver)) {
       this->complete = [](pop_waiter* w) noexcept {
         auto& op = *static_cast<operation*>(w);
-        op.stop_callback.reset();
+        op.easy_cancel.reset();
         if (op.result) {
           STDEX_CONQUEUE_LOG("async_pop: resumed with lvalue: %d\n",
                              *op.result);
@@ -508,14 +507,10 @@ struct buffer_queue<T, Alloc>::pop_sender {
 
     friend void tag_invoke(stdexec::start_t, operation& op) noexcept {
       auto& self = op.queue;
-      auto stop_token = stdexec::get_stop_token(stdexec::get_env(op.receiver));
-      constexpr bool stoppable = !std::unstoppable_token<decltype(stop_token)>;
 
-      if constexpr (stoppable) {
-        if (stop_token.stop_requested()) {
-          stdexec::set_stopped((Receiver&&)op.receiver);
-          return;
-        }
+      if (op.easy_cancel.stop_requested()) {
+        stdexec::set_stopped((Receiver&&)op.receiver);
+        return;
       }
 
       std::unique_lock lock(self.mutex);
@@ -556,12 +551,7 @@ struct buffer_queue<T, Alloc>::pop_sender {
         self.pop_waiters.push_back(&op);
         lock.unlock();
 
-        if constexpr (stoppable) {
-          if (stop_token.stop_possible()) {
-            op.stop_callback.emplace(std::move(stop_token),
-                                     cancel_callback{op});
-          }
-        }
+        op.easy_cancel.register_callback(cancel_callback{op});
         return;
       }
 

--- a/test/conqueue.test.cpp
+++ b/test/conqueue.test.cpp
@@ -160,13 +160,25 @@ exec::task<void> coro_stuck_pop(buffer_queue<int>& q) {
   co_await q.async_pop();
 }
 
-TEST_CASE("conqueue: cancellation") {
+TEST_CASE("conqueue: cancellation async_pop") {
   exec::static_thread_pool pool(1);
   auto sched = pool.get_scheduler();
   exec::async_scope scope;
   buffer_queue<int> q(2);
 
   scope.spawn(on(sched, coro_stuck_pop(q)));
+  std::this_thread::sleep_for(10ms);
+  scope.request_stop();
+  stdexec::sync_wait(scope.on_empty());
+}
+
+TEST_CASE("conqueue: cancellation async_push") {
+  exec::static_thread_pool pool(1);
+  auto sched = pool.get_scheduler();
+  exec::async_scope scope;
+  buffer_queue<int> q(0);
+
+  scope.spawn(on(sched, coro_push(q)));
   std::this_thread::sleep_for(10ms);
   scope.request_stop();
   stdexec::sync_wait(scope.on_empty());

--- a/test/conqueue.test.cpp
+++ b/test/conqueue.test.cpp
@@ -155,3 +155,19 @@ TEST_CASE("conqueue: coro_push rendezvous") {
 
   stdexec::sync_wait(scope.on_empty());
 }
+
+exec::task<void> coro_stuck_pop(buffer_queue<int>& q) {
+  co_await q.async_pop();
+}
+
+TEST_CASE("conqueue: cancellation") {
+  exec::static_thread_pool pool(1);
+  auto sched = pool.get_scheduler();
+  exec::async_scope scope;
+  buffer_queue<int> q(2);
+
+  scope.spawn(on(sched, coro_stuck_pop(q)));
+  std::this_thread::sleep_for(10ms);
+  scope.request_stop();
+  stdexec::sync_wait(scope.on_empty());
+}


### PR DESCRIPTION
No need for atomic<boo> ready or any other synchronization for cancel, since, we already have a mutex and a waiter queue